### PR TITLE
Improve LSP files detection in OLEfile_in_CAD_FAS_LSP

### DIFF
--- a/rules/OLEfile_in_CAD_FAS_LSP.yar
+++ b/rules/OLEfile_in_CAD_FAS_LSP.yar
@@ -10,14 +10,14 @@ meta:
 strings:
 	$acad = {41 43 31} //AC1 (old format follows with 0x2E, new with 0x30)
 	$fas = {0D 0A 20 46 41 53 34 2D 46 49 4C 45 20 3B 20 44 6F 20 6E 6F 74 20 63 68 61 6E 67 65 20 69 74 21}
-	$lsp1 = "acaddoc.lsp"
-	$lsp2 = "doc.lsp"
-	$lsp3 = "doclsp"
-	$lsp4 = "lspfilelist"
+	$lsp1 = "lspfilelist"
+	$lsp2 = "setq"
+	$lsp3 = ".lsp"
+	$lsp4 = "acad.mnl"
 	$ole = {D0 CF 11 E0}
 
 condition:
 	($acad at 0 and $ole) or
 	($fas at 0 and $ole) or
-	((any of ($lsp*)) and $ole)
+	((all of ($lsp*)) and $ole)
 }


### PR DESCRIPTION
The current condition to detect LSP files leads to false positives (i.e. an zip with a doc.lsp file inside). [Results](https://user-images.githubusercontent.com/2981066/89296727-07409200-d663-11ea-9b9a-0760ccd37ba6.png)
I tried to improve it a bit by changing the lsp strings and condition ([results](https://user-images.githubusercontent.com/2981066/89296917-5c7ca380-d663-11ea-91e9-c8037d647989.png)).
