### PR TITLE
Update IcedID.yar to avoid False positives in HTML and PCAPs

### DIFF
--- a/rules/crimeware/IcedID.yar
+++ b/rules/crimeware/IcedID.yar
@@ -29,7 +29,8 @@ rule IcedID_init_loader
         $x6 = "Cookie: __gads=" ascii wide
 
     condition:
-        2 of ($s*) or 3 of ($x*)
+        int16(0) == 0x5a4d
+        and 2 of ($s*) or 3 of ($x*)
 }
 
 rule IcedID_core_loader


### PR DESCRIPTION
We see a lot of false positives for this rule. 

IcedID uses google analytics cookie names for these values, and this is what this rule detects. 

This is a problem, because you'll find a lot of google analytics cookies in Pcaps, python scripts,  html files, etc. I suggest restricting the detection to PE files, should solve most of the false positives for this