### PR TITLE
Update Webshell_in_image.yar

### DIFF
--- a/rules/generic/Webshell_in_image.yar
+++ b/rules/generic/Webshell_in_image.yar
@@ -21,11 +21,15 @@ rule Webshell_in_image
         $jpeg = {FF D8 FF E0}
         $bmp = {42 4D}
         $s1 = "<%@ Page Language=" ascii wide
-        $s2 = "<?php" ascii wide nocase
-        $s3 = "eval(" ascii wide nocase
-        $s4 = "<eval" ascii wide nocase
-        $s5 = "<%eval" ascii wide nocase
+        $s2 = /<\?php[ -~]{30,}/ ascii wide nocase
+        $s3 = /eval\([ -~]{30,}/ ascii wide nocase
+        $s4 = /<eval[ -~]{30,}/ ascii wide nocase
+        $s5 = /<%eval[ -~]{30,}/ ascii wide nocase
 
     condition:
         ($gif at 0 and any of ($s*)) or ($png at 0 and any of ($s*)) or ($jpeg at 0 and any of ($s*)) or ($bmp at 0 and any of ($s*))
 }
+
+
+
+


### PR DESCRIPTION
Fixed FPs in webshell rule. 

The small ascii nocase strings are often found in the high entropy data found in images. 

I converted them to regexes, with a condition that they must be followed by at least 30 printable chars. This should stopmost of the FPs.